### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -250,7 +250,7 @@ FingerText 0.3.5 or below use a "one snippet per file" system to store snippets,
 - Fixed: inclusive triggertext complete not working
 - improve start up performance by removing redundant updateScintilla calls
 - update the settings hint
-- Changed: undo after a tab triggertext completetion will become a regular tab
+- Changed: undo after a tab triggertext completion will become a regular tab
 - Fixed: undo works properly after params insertion
 - Changed: params insertion can accept values with hotspot tags
 - the limit of option numbers is lifted


### PR DESCRIPTION
@erinata, I've corrected a typographical error in the documentation of the [FingerText](https://github.com/erinata/FingerText) project. Specifically, I've changed completetion to completion. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
