### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/DialogFeatures/DockingDlgInterface.h
+++ b/DialogFeatures/DockingDlgInterface.h
@@ -40,7 +40,7 @@ public:
 
     void create(tTbData * data, bool isRTL = false){
 		StaticDialog::create(_dlgID, isRTL);
-		::GetWindowText(_hSelf, _pluginName, sizeof(_pluginName));
+		::GetWindowText(_hSelf, _pluginName, sizeof(_pluginName)/sizeof(TCHAR));
 
         // user information
 		data->hClient		= _hSelf;

--- a/PluginDefinition.cpp
+++ b/PluginDefinition.cpp
@@ -589,7 +589,7 @@ void insertSnippet()
     diagActivate(tempTriggerText);
     ::SetFocus(::getCurrentScintilla());
 
-    
+	delete[] tempScope;
 }
 
 
@@ -1692,7 +1692,7 @@ void evaluateHotSpot(int &firstPos, char* hotSpotText)
             //secondPos = secondPos - (delimitEnd + 2 - (firstPos + 5));
             
         } 
-    } if (strncmp(hotSpotText,"TERNARY'",8) == 0)
+    } else if (strncmp(hotSpotText,"TERNARY'",8) == 0)
     {
         mode = 0;
         
@@ -5610,14 +5610,9 @@ void httpToFile(TCHAR* server, TCHAR* request, TCHAR* requestType, TCHAR* pathWi
             }
     
             // Allocate space for the buffer.
-            pszOutBuffer = new char[dwSize+1];
+			try {
+				pszOutBuffer = new char[dwSize+1];
     
-            if (!pszOutBuffer)
-            {
-                showMessageBox(TEXT("Out of memory."));
-                dwSize=0;
-            } else
-            {
                 // Read the Data.
                 ZeroMemory(pszOutBuffer, dwSize+1);
     
@@ -5632,6 +5627,12 @@ void httpToFile(TCHAR* server, TCHAR* request, TCHAR* requestType, TCHAR* pathWi
                 // Free the memory allocated to the buffer.
                 delete [] pszOutBuffer;
             }
+			catch (const std::bad_alloc& e)
+			{
+				showMessageBox(TEXT("Out of memory."));
+				dwSize = 0;
+			}
+
         } while (dwSize>0);
     }
     fclose (pFile);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V575](https://www.viva64.com/en/w/v575/) The number of processed elements should be passed to the 'GetWindowTextW' function as the third argument instead of buffer's size in bytes. dockingdlginterface.h 43
[V646](https://www.viva64.com/en/w/v646/) Consider inspecting the application's logic. It's possible that 'else' keyword is missing. plugindefinition.cpp 1695
[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'pszOutBuffer' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. plugindefinition.cpp 5615
[V773](https://www.viva64.com/en/w/v773/) Visibility scope of the 'tempScope' pointer was exited without releasing the memory. A memory leak is possible. plugindefinition.cpp 593